### PR TITLE
Release/1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2 (2025-03-10)
+
+- ✅ The command "ccli get --tree" now shows associated aliases when using the --tree flag (#2)
+- ✅ The command "ccli get" now separates keys from values with a colon (#3)
+
 ## 1.0.1 (2025-03-04)
 
 Patch release with a bug fix for aliases, better comments, and optimizations

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -31,9 +31,9 @@ function displayEntries(entries: Record<string, string>): void {
     const aliases = getAliasesForPath(key);
     
     if (aliases.length > 0) {
-      console.log(`${colorizedPath} ${color.blue('(' + aliases[0] + ')')} ${value}`);
+      console.log(`${colorizedPath}: ${color.blue('(' + aliases[0] + ')')} ${value}`);
     } else {
-      console.log(`${colorizedPath} ${value}`);
+      console.log(`${colorizedPath}: ${value}`);
     }
   });
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -83,9 +83,21 @@ export function getEntry(key?: string, options: any = {}): void {
       return;
     }
 
-    // Handle tree display for all entries
+    // Handle tree display for all entries with alias information
     if (options.tree) {
-      displayTree(data);
+      // Load all aliases to check against keys
+      const aliases = loadAliases();
+      // Create a mapping from keys to aliases with proper typing
+      const keyToAliasMap: Record<string, string[]> = {};
+      
+      for (const [alias, target] of Object.entries(aliases)) {
+        if (!keyToAliasMap[target]) {
+          keyToAliasMap[target] = [];
+        }
+        keyToAliasMap[target].push(alias);
+      }
+      
+      displayTree(data, keyToAliasMap);
       return;
     }
 
@@ -153,7 +165,18 @@ export function getEntry(key?: string, options: any = {}): void {
   if (typeof value === 'object' && value !== null) {
     // For tree display
     if (options.tree) {
-      displayTree({ [key]: value });
+      // Load aliases to include in tree display
+      const aliases = loadAliases();
+      const keyToAliasMap: Record<string, string[]> = {};
+      
+      for (const [alias, target] of Object.entries(aliases)) {
+        if (!keyToAliasMap[target]) {
+          keyToAliasMap[target] = [];
+        }
+        keyToAliasMap[target].push(alias);
+      }
+      
+      displayTree({ [key]: value }, keyToAliasMap);
       return;
     }
     
@@ -272,7 +295,19 @@ export function searchEntries(searchTerm: string, options: any = {}): void {
     Object.keys(matches).forEach(key => {
       setNestedValue(matchesObj, key, matches[key]);
     });
-    displayTree(matchesObj);
+    
+    // Load aliases to include in tree display
+    const aliases = loadAliases();
+    const keyToAliasMap: Record<string, string[]> = {};
+    
+    for (const [alias, target] of Object.entries(aliases)) {
+      if (!keyToAliasMap[target]) {
+        keyToAliasMap[target] = [];
+      }
+      keyToAliasMap[target].push(alias);
+    }
+    
+    displayTree(matchesObj, keyToAliasMap);
     return;
   }
   

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -144,7 +144,7 @@ export function showHelp(): void {
 /**
  * Display data in a tree format
  */
-export function displayTree(data: object, prefix: string = ''): void {
+export function displayTree(data: object, keyToAliasMap: Record<string, string[]> = {}, prefix = '', path = ''): void {
   const colorEnabled = isColorEnabled();
   
   Object.entries(data).forEach(([key, value], index, array) => {
@@ -154,13 +154,18 @@ export function displayTree(data: object, prefix: string = ''): void {
     
     const displayKey = colorEnabled ? color.cyan(key) : key;
     
+    // Remove unused variable and just use fullPath
+    const fullPath = path ? `${path}.${key}` : key;
+    const aliases = keyToAliasMap[fullPath];
+    const aliasDisplay = aliases && aliases.length > 0 ? ` (${aliases[0]})` : '';
+    
     if (typeof value === 'object' && value !== null) {
-      console.log(`${fullPrefix}${displayKey}`);
+      console.log(`${fullPrefix}${displayKey}${aliasDisplay}`);
       const childPrefix = prefix + (isLast ? ' '.repeat(4) : '│   ');
-      displayTree(value, childPrefix);
+      displayTree(value, keyToAliasMap, childPrefix, fullPath);
     } else {
       const displayValue = colorEnabled ? color.white(value) : value;
-      console.log(`${fullPrefix}${displayKey}: ${displayValue}`);
+      console.log(`${fullPrefix}${displayKey}${aliasDisplay}: ${displayValue}`);
     }
   });
 }


### PR DESCRIPTION
- The command "ccli get --tree" now shows associated aliases when using the --tree flag
(#2)
- The command "ccli get" now separates keys from values with a colon
(#3)